### PR TITLE
Add connector for Klassik Radio

### DIFF
--- a/src/connectors/klassikradio.de.js
+++ b/src/connectors/klassikradio.de.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Connector.playerSelector = '#audioPlayer';
+
+Connector.artistSelector = '.trackInfos-artist';
+
+Connector.trackSelector = '.trackInfos-title';
+
+Connector.playButtonSelector = '#playButton';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1872,6 +1872,13 @@ const connectors = [{
 	],
 	js: 'connectors/zeno.js',
 	id: 'zeno',
+}, {
+	label: 'Klassik Radio',
+	matches: [
+		'*://*klassikradio.de/*',
+	],
+	js: 'connectors/klassikradio.de.js',
+	id: 'klassikradio',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
Klassik Radio is a radio station in Germany. It specialises in classical 
music, Film music and Lounge music. The channel is receivable in over 
300 German cities via FM, throughout Germany via cable, and in Europe 
via satellite. It is also worldwide streamed on the internet.