### PR TITLE
Add connector for lulu.fm

### DIFF
--- a/src/connectors/lulu.fm.js
+++ b/src/connectors/lulu.fm.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Connector.playerSelector = '#qtmplayer';
+
+Connector.artistSelector = '.qtmplayer__artist';
+
+Connector.trackSelector = '.qtmplayer__title';
+
+Connector.isPlaying = () => Util.getTextFromSelectors('#qtmplayerTime') !== '00:00';
+
+Connector.getTrackArt = () => {
+	const trackArtUrl = Util.extractImageUrlFromSelectors('.qtmplayer__cover img');
+	if (trackArtUrl) {
+		return trackArtUrl;
+	}
+	return null;
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2370,6 +2370,13 @@ const connectors = [{
 	],
 	js: 'connectors/dr-lyd.js',
 	id: 'dr-lyd',
+},	{
+	label: 'lulu.fm',
+	matches: [
+		'*://*lulu.fm/*',
+	],
+	js: 'connectors/lulu.fm.js',
+	id: 'lulufm',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
lulu.fm, das queere Radio

Köln: UKW 94.5 MHz
Berlin: UKW 104.1 MHz & DAB+
Hamburg: DAB+
Rhein-Main/Neckar: DAB+
Leipzig: DAB+
Wien: DAB+

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

**Additional context**
<!-- Add any other context or screenshots here. -->
